### PR TITLE
The solution partially copies the logic of the built-in HashMap, with…

### DIFF
--- a/src/main/java/core/basesyntax/MyHashMap.java
+++ b/src/main/java/core/basesyntax/MyHashMap.java
@@ -6,33 +6,47 @@ import java.util.Objects;
 public class MyHashMap<K, V> implements MyMap<K, V> {
     private static final int DEFAULT_INITIAL_CAPACITY = 1 << 4;
     private static final float DEFAULT_LOAD_FACTOR = 0.75f;
-    private Node<K, V>[] hashTable;
-    private int threshold = DEFAULT_INITIAL_CAPACITY * (int) DEFAULT_LOAD_FACTOR;
+    private Node<K, V>[] table;
+    private int threshold;
     private int size;
 
     public MyHashMap() {
+        table = new Node[DEFAULT_INITIAL_CAPACITY];
+        threshold = (int) DEFAULT_LOAD_FACTOR * DEFAULT_INITIAL_CAPACITY;
     }
 
     @Override
     public void put(K key, V value) {
-        if (size > threshold || hashTable == null) {
+        if (size > threshold) {
             resize();
         }
-        putValue(indexFromHash(key), key, value);
-        size++;
+        int index = indexFromHash(key);
+        if (table[index] == null) {
+            table[index] = new Node<>(key, value);
+            size++;
+        } else {
+            for (Node<K, V> node = table[index]; node != null; node = node.next) {
+                if (Objects.equals(key, node.key)) {
+                    node.value = value;
+                    return;
+                }
+                if (node.next == null) {
+                    node.next = new Node<>(key, value);
+                    size++;
+                }
+            }
+        }
     }
 
     @Override
     public V getValue(K key) {
-        if (hashTable != null) {
-            int index = indexFromHash(key);
-            Node<K, V> currentNode = hashTable[index];
-            while (currentNode != null) {
-                if (Objects.equals(key, currentNode.getKey())) {
-                    return currentNode.getValue();
-                }
-                currentNode = currentNode.next;
+        int index = indexFromHash(key);
+        Node<K, V> currentNode = table[index];
+        while (currentNode != null) {
+            if (Objects.equals(key, currentNode.key)) {
+                return currentNode.value;
             }
+            currentNode = currentNode.next;
         }
         return null;
     }
@@ -51,48 +65,14 @@ public class MyHashMap<K, V> implements MyMap<K, V> {
             this.key = key;
             this.value = value;
         }
-
-        public K getKey() {
-            return key;
-        }
-
-        public V getValue() {
-            return value;
-        }
-
-        public void setValue(V value) {
-            this.value = value;
-        }
-    }
-
-    private void putValue(int index, K key, V value) {
-        if (hashTable[index] == null) {
-            hashTable[index] = new Node<>(key, value);
-        } else {
-            Node<K, V> currentNode = hashTable[index];
-            while (currentNode.next != null) {
-                if (Objects.equals(key, currentNode.getKey())) {
-                    break;
-                }
-                currentNode = currentNode.next;
-            }
-            if (Objects.equals(key, currentNode.getKey())) {
-                currentNode.setValue(value);
-                size--;
-            } else {
-                currentNode.next = new Node<>(key, value);
-            }
-        }
     }
 
     private void resize() {
-        if (hashTable == null) {
-            hashTable = new Node[DEFAULT_INITIAL_CAPACITY];
-        }
-        int newCapacity = hashTable.length << 1;
+        size = 0;
+        int newCapacity = table.length << 1;
         threshold = (int) (DEFAULT_LOAD_FACTOR * newCapacity);
-        Node<K, V>[] oldHashTable = hashTable;
-        hashTable = new Node[newCapacity];
+        Node<K, V>[] oldHashTable = table;
+        table = new Node[newCapacity];
         transfer(oldHashTable);
     }
 
@@ -100,13 +80,13 @@ public class MyHashMap<K, V> implements MyMap<K, V> {
         for (Node<K, V> node : oldHashTable) {
             Node<K, V> newNode = node;
             while (newNode != null) {
-                putValue(indexFromHash(newNode.getKey()), newNode.getKey(), newNode.getValue());
+                put(newNode.key, newNode.value);
                 newNode = newNode.next;
             }
         }
     }
 
     private int indexFromHash(K key) {
-        return key == null ? 0 : Math.abs(key.hashCode() % hashTable.length);
+        return key == null ? 0 : Math.abs(key.hashCode() % table.length);
     }
 }

--- a/src/main/java/core/basesyntax/MyHashMap.java
+++ b/src/main/java/core/basesyntax/MyHashMap.java
@@ -18,14 +18,14 @@ public class MyHashMap<K, V> implements MyMap<K, V> {
         if (size > threshold || hashTable == null) {
             resize();
         }
-        putValue(hash(key), key, value);
+        putValue(indexFromHash(key), key, value);
         size++;
     }
 
     @Override
     public V getValue(K key) {
         if (hashTable != null) {
-            int index = hash(key);
+            int index = indexFromHash(key);
             Node<K, V> currentNode = hashTable[index];
             while (currentNode != null) {
                 if (Objects.equals(key, currentNode.getKey())) {
@@ -65,11 +65,11 @@ public class MyHashMap<K, V> implements MyMap<K, V> {
         }
     }
 
-    private void putValue(int hash, K key, V value) {
-        if (hashTable[hash] == null) {
-            hashTable[hash] = new Node<>(key, value);
+    private void putValue(int index, K key, V value) {
+        if (hashTable[index] == null) {
+            hashTable[index] = new Node<>(key, value);
         } else {
-            Node<K, V> currentNode = hashTable[hash];
+            Node<K, V> currentNode = hashTable[index];
             while (currentNode.next != null) {
                 if (Objects.equals(key, currentNode.getKey())) {
                     break;
@@ -100,13 +100,13 @@ public class MyHashMap<K, V> implements MyMap<K, V> {
         for (Node<K, V> node : oldHashTable) {
             Node<K, V> newNode = node;
             while (newNode != null) {
-                putValue(hash(newNode.getKey()), newNode.getKey(), newNode.getValue());
+                putValue(indexFromHash(newNode.getKey()), newNode.getKey(), newNode.getValue());
                 newNode = newNode.next;
             }
         }
     }
 
-    private int hash(K key) {
+    private int indexFromHash(K key) {
         return key == null ? 0 : Math.abs(key.hashCode() % hashTable.length);
     }
 }

--- a/src/main/java/core/basesyntax/MyHashMap.java
+++ b/src/main/java/core/basesyntax/MyHashMap.java
@@ -1,19 +1,112 @@
 package core.basesyntax;
 
+import java.util.Objects;
+
+@SuppressWarnings("unchecked")
 public class MyHashMap<K, V> implements MyMap<K, V> {
+    private static final int DEFAULT_INITIAL_CAPACITY = 1 << 4;
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+    private Node<K, V>[] hashTable;
+    private int threshold = DEFAULT_INITIAL_CAPACITY * (int) DEFAULT_LOAD_FACTOR;
+    private int size;
+
+    public MyHashMap() {
+    }
 
     @Override
     public void put(K key, V value) {
-
+        if (size > threshold || hashTable == null) {
+            resize();
+        }
+        putValue(hash(key), key, value);
+        size++;
     }
 
     @Override
     public V getValue(K key) {
+        if (hashTable != null) {
+            int index = hash(key);
+            Node<K, V> currentNode = hashTable[index];
+            while (currentNode != null) {
+                if (Objects.equals(key, currentNode.getKey())) {
+                    return currentNode.getValue();
+                }
+                currentNode = currentNode.next;
+            }
+        }
         return null;
     }
 
     @Override
     public int getSize() {
-        return 0;
+        return size;
+    }
+
+    private static class Node<K, V> {
+        private final K key;
+        private V value;
+        private Node<K, V> next;
+
+        private Node(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+        public V getValue() {
+            return value;
+        }
+
+        public void setValue(V value) {
+            this.value = value;
+        }
+    }
+
+    private void putValue(int hash, K key, V value) {
+        if (hashTable[hash] == null) {
+            hashTable[hash] = new Node<>(key, value);
+        } else {
+            Node<K, V> currentNode = hashTable[hash];
+            while (currentNode.next != null) {
+                if (Objects.equals(key, currentNode.getKey())) {
+                    break;
+                }
+                currentNode = currentNode.next;
+            }
+            if (Objects.equals(key, currentNode.getKey())) {
+                currentNode.setValue(value);
+                size--;
+            } else {
+                currentNode.next = new Node<>(key, value);
+            }
+        }
+    }
+
+    private void resize() {
+        if (hashTable == null) {
+            hashTable = new Node[DEFAULT_INITIAL_CAPACITY];
+        }
+        int newCapacity = hashTable.length << 1;
+        threshold = (int) (DEFAULT_LOAD_FACTOR * newCapacity);
+        Node<K, V>[] oldHashTable = hashTable;
+        hashTable = new Node[newCapacity];
+        transfer(oldHashTable);
+    }
+
+    private void transfer(Node<K, V>[] oldHashTable) {
+        for (Node<K, V> node : oldHashTable) {
+            Node<K, V> newNode = node;
+            while (newNode != null) {
+                putValue(hash(newNode.getKey()), newNode.getKey(), newNode.getValue());
+                newNode = newNode.next;
+            }
+        }
+    }
+
+    private int hash(K key) {
+        return key == null ? 0 : Math.abs(key.hashCode() % hashTable.length);
     }
 }


### PR DESCRIPTION
… the exception of threshold, which is initialized immediately.

Overridden put(K key, V value) method from the MyMap<K, V> interface. Since the newly created MyHashMap == null, we must initialize it in the resize() method. Also, resize() increases the size of the MyHashMap array when the number of values reaches a critical point. After that, we add a new node.

Overridden method from interface MyMap<K, V>.
It returns value by key and expects that the bucket may contain a List. Otherwise returns null.

Overridden getSize() method from MyMap<K, V> interface. The method returns the size;

Added class Node.
The hash variable is excluded from it, as well as the equals and hashCode methods due to the specifics of the task and implementation.

Added private void putValue(int hash, K key, V value). It expects adding Node: with key null; duplicate; and generates a list in the bucket if it was already occupied by another Node.

Added private void method resize().
It initializes an empty hashTable when the first element is added. It also doubles the size of the array if necessary, and also calls the transfer() method to transfer nodes from the old table to the new one.

Added private void transfer(Node<K, V>[] oldHashTable) method. Its task is to through all existing elements in the old table and use putValue() to determine them to buckets in the new table.

Added private int hash(K key) method.
With it, we determine in which bucket will be the new Node.